### PR TITLE
Add "lang" attribute to HTML tag of webpages

### DIFF
--- a/NeoWeb/Views/Shared/_Layout.cshtml
+++ b/NeoWeb/Views/Shared/_Layout.cshtml
@@ -16,7 +16,10 @@ https://neo.org/
 Want to make this site better?
 https://github.com/neo-project/neo.org
 -->
-<html>
+@{
+    var langCode = @SharedLocalizer["en"].Value;
+}
+<html lang="@langCode">
 <head prefix="og: http://ogp.me/ns#">
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
This will allow better customization of CSS and JS for i18n variants.

Example outcome for English pages:

```html
<html lang="en">
```

Example outcome for Chinese pages:

```html
<html lang="zh">
```
