### PR TITLE
Feature/caption square

### DIFF
--- a/NeoWeb/Resources/Views.Home.Index.zh.resx
+++ b/NeoWeb/Resources/Views.Home.Index.zh.resx
@@ -144,9 +144,6 @@
   <data name="Blockchain" xml:space="preserve">
     <value>区块链</value>
   </data>
-  <data name="Building Blocks" xml:space="preserve">
-    <value>基石</value>
-  </data>
   <data name="Community" xml:space="preserve">
     <value>社区</value>
   </data>
@@ -183,8 +180,8 @@
   <data name="For holding NEO" xml:space="preserve">
     <value>持有 NEO</value>
   </data>
-  <data name="for the Next Generation Internet" xml:space="preserve">
-    <value>下一代 &lt;br /&gt; 互联网的</value>
+  <data name="&lt;em&gt;Building Blocks&lt;/em&gt; for the Next Generation Internet" xml:space="preserve">
+    <value>下一代 &lt;br /&gt; 互联网的&lt;br /&gt;&lt;em&gt;基石&lt;/em&gt;</value>
   </data>
   <data name="GAS is used to pay for network fees, smart contract deployments, and in dApp purchases." xml:space="preserve">
     <value>GAS 可以被用来支付 Neo 区块链上的网络费用、智能合约部署费用，以及 dAPP 内购等。</value>
@@ -333,7 +330,16 @@
   <data name="Write your smart contracts in C#, Go, Python, Java, or TypeScript." xml:space="preserve">
     <value>用 C#、Python、Go、Java 或 TypeScript 编写你的智能合约</value>
   </data>
-  <data name="You know" xml:space="preserve">
-    <value>你已经熟知的</value>
+  <data name="&lt;em&gt;Blockchain&lt;/em&gt;&lt;br /&gt;You know" xml:space="preserve">
+    <value>你已经熟知的&lt;br /&gt;&lt;em&gt;区块链&lt;/em&gt;</value>
+  </data>
+  <data name="&lt;em&gt;Dual&lt;/em&gt;&lt;br /&gt;Tokens" xml:space="preserve">
+    <value>&lt;em&gt;双通证&lt;/em&gt;&lt;br /&gt;机制</value>
+  </data>
+  <data name="&lt;em&gt;On-chain&lt;/em&gt;&lt;br /&gt;Governance" xml:space="preserve">
+    <value>&lt;em&gt;链上&lt;/em&gt;&lt;br /&gt;治理</value>
+  </data>
+  <data name="&lt;em&gt;Global&lt;/em&gt;&lt;br /&gt;Contributors" xml:space="preserve">
+    <value>&lt;em&gt;全球&lt;/em&gt;&lt;br /&gt;贡献者</value>
   </data>
 </root>

--- a/NeoWeb/Views/Home/Index.cshtml
+++ b/NeoWeb/Views/Home/Index.cshtml
@@ -127,7 +127,7 @@
 
         @{
             ViewData["CS_customClasses"] = "blockchain";
-            ViewData["CS_title"] = @Localizer["Blockchain You know"].Value;
+            ViewData["CS_title"] = @Localizer["<em>Blockchain</em><br />You know"].Value;
             ViewData["CS_subtitle"] = @Localizer["Write smart contracts in a language you already love"].Value;
         }
         <partial name="../_Common/_CaptionSquare" view-data="ViewData" />
@@ -209,18 +209,12 @@
 
     <div class="dual-tokens-row">
         <div class="col-left">
-
-            <div class="square-block dual-tokens">
-                <div class="square-block-title">
-                    <span class="green">@Localizer["Dual"]</span><br />
-                    @Localizer["Tokens"]
-                </div>
-                <div class="square-block-subtitle">
-                    @Localizer["Neo has a unique dual token model that separates governance from utility."]
-                </div>
-            </div>
-
-
+            @{
+                ViewData["CS_customClasses"] = "dual-tokens";
+                ViewData["CS_title"] = @Localizer["<em>Dual</em><br />Tokens"].Value;
+                ViewData["CS_subtitle"] = @Localizer["Neo has a unique dual token model that separates governance from utility."].Value;
+            }
+            <partial name="../_Common/_CaptionSquare" view-data="ViewData" />
         </div>
         <div class="col-right header-imgs">
             <div class="header-img-wrapper">
@@ -353,15 +347,13 @@
             </div>
         </div>
         <div class="col-right">
-            <div class="square-block governance">
-                <div class="square-block-title governance">
-                    <span class="green">@Localizer["On-chain"]</span><br />
-                    @Localizer["Governance"]
-                </div>
-                <div class="square-block-subtitle governance">
-                    @Localizer["A dynamic on-chain council voted in by the NEO token holders."]
-                </div>
-            </div>
+            @{
+                ViewData["CS_customClasses"] = "governance";
+                ViewData["CS_title"] = @Localizer["<em>On-chain</em><br />Governance"].Value;
+                ViewData["CS_subtitle"] = @Localizer["A dynamic on-chain council voted in by the NEO token holders."].Value;
+            }
+            <partial name="../_Common/_CaptionSquare" view-data="ViewData" />
+
             <div class="governance-paragraph">
                 <span>
                     @Localizer["N3 introduces the ability for NEO holders to vote in council members and consensus nodes that maintain the liveliness of the Neo network and adjust critical blockchain parameters."]
@@ -381,15 +373,13 @@
                 <img class="governance-img-vert" src="@Helper.ToCDN("/images/transparent.png")" data-original="@Helper.ToCDN("/images/home/GovernanceTablet.svg")" />
             </div>
             <div class="col-right">
-                <div class="square-block governance">
-                    <div class="square-block-title governance">
-                        <span class="green">@Localizer["On-chain"]</span><br />
-                        @Localizer["Governance"]
-                    </div>
-                    <div class="square-block-subtitle governance">
-                        @Localizer["A dynamic on-chain council voted in by the NEO token holders."]
-                    </div>
-                </div>
+                @{
+                    ViewData["CS_customClasses"] = "governance";
+                    ViewData["CS_title"] = @Localizer["<em>On-chain</em><br />Governance"].Value;
+                    ViewData["CS_subtitle"] = @Localizer["A dynamic on-chain council voted in by the NEO token holders."].Value;
+                }
+                <partial name="../_Common/_CaptionSquare" view-data="ViewData" />
+
                 <div class="governance-paragraph">
                     <span>
                         @Localizer["N3 introduces the ability for NEO holders to vote in council members and consensus nodes that maintain the liveliness of the Neo network and adjust critical blockchain parameters."]
@@ -421,15 +411,13 @@
     </div>
 
     <div class="governance-section-mobile">
-        <div class="square-block governance">
-            <div class="square-block-title governance">
-                <span class="green">@Localizer["On-chain"]</span><br />
-                @Localizer["Governance"]
-            </div>
-            <div class="square-block-subtitle governance">
-                @Localizer["A dynamic on-chain council voted in by the NEO token holders."]
-            </div>
-        </div>
+        @{
+            ViewData["CS_customClasses"] = "governance";
+            ViewData["CS_title"] = @Localizer["<em>On-chain</em><br />Governance"].Value;
+            ViewData["CS_subtitle"] = @Localizer["A dynamic on-chain council voted in by the NEO token holders."].Value;
+        }
+        <partial name="../_Common/_CaptionSquare" view-data="ViewData" />
+
         <div class="governance-img-container">
             <img class="governance-img-vert" src="@Helper.ToCDN("/images/transparent.png")" data-original="@Helper.ToCDN("/images/home/GovernanceTablet.svg")" />
         </div>
@@ -467,15 +455,12 @@
 
     <div class="contributors-row">
         <div class="col-left">
-            <div class="square-block contributors">
-                <div class="square-block-title contributors">
-                    <span class="green">@Localizer["Global"]</span><br />
-                    @Localizer["Contributors"]
-                </div>
-                <div class="square-block-subtitle contributors">
-                    @Localizer["Neo is a joint effort by community groups from all over the world."]
-                </div>
-            </div>
+            @{
+                ViewData["CS_customClasses"] = "contributors";
+                ViewData["CS_title"] = @Localizer["<em>Global</em><br />Contributors"].Value;
+                ViewData["CS_subtitle"] = @Localizer["Neo is a joint effort by community groups from all over the world."].Value;
+            }
+            <partial name="../_Common/_CaptionSquare" view-data="ViewData" />
         </div>
         <div class="col-right">
             <div class="github-container">

--- a/NeoWeb/Views/Home/Index.cshtml
+++ b/NeoWeb/Views/Home/Index.cshtml
@@ -125,14 +125,15 @@
 
         <partial name="./_NeoFeatures" />
 
-        @{
-            ViewData["CS_customClasses"] = "blockchain";
-            ViewData["CS_title"] = @Localizer["<em>Blockchain</em><br />You know"].Value;
-            ViewData["CS_subtitle"] = @Localizer["Write smart contracts in a language you already love"].Value;
-        }
-        <partial name="../_Common/_CaptionSquare" view-data="ViewData" />
-
-        <a class="btn-2 code-learn-more" href="/technology#smart-contracts">@Localizer["Learn More"]</a>
+        <div class="blockchain-caption-square-row">
+            @{
+                ViewData["CS_customClasses"] = "blockchain";
+                ViewData["CS_title"] = @Localizer["<em>Blockchain</em><br />You know"].Value;
+                ViewData["CS_subtitle"] = @Localizer["Write smart contracts in a language you already love"].Value;
+            }
+            <partial name="../_Common/_CaptionSquare" view-data="ViewData" />
+            <a class="btn-2 code-learn-more" href="/technology#smart-contracts">@Localizer["Learn More"]</a>
+        </div>
     </div>
 
     <div class="code-example-row">

--- a/NeoWeb/Views/Home/Index.cshtml
+++ b/NeoWeb/Views/Home/Index.cshtml
@@ -102,21 +102,11 @@
     <div class="building-blocks-container">
         <div class="building-blocks-row">
             <div class="col-left">
-                <div class="square-block building-blocks @SharedLocalizer["d-none-zh"]">
-                    <div class="square-block-title">
-                        <span class="green">
-                            @Localizer["Building Blocks"]
-                        </span> @Localizer["for the Next Generation Internet"]
-                    </div>
-                </div>
-                <div class="square-block building-blocks zh @SharedLocalizer["d-none"]">
-                    <div class="square-block-title">
-                        @Localizer["for the Next Generation Internet"]<br />
-                        <span class="green">
-                            @Localizer["Building Blocks"]
-                        </span>
-                    </div>
-                </div>
+                @{
+                    ViewData["CS_customClasses"] = "building-blocks";
+                    ViewData["CS_title"] = @Localizer["<em>Building Blocks</em> for the Next Generation Internet"].Value;
+                }
+                <partial name="../_Common/_CaptionSquare" view-data="ViewData" />
             </div>
             <div class="col-right">
                 <span>
@@ -135,23 +125,13 @@
 
         <partial name="./_NeoFeatures" />
 
-        <div class="square-block blockchain">
-            <div class="square-block-title @SharedLocalizer["d-none-zh"]">
-                <span class="green">
-                    @Localizer["Blockchain"]
-                </span>
-                <br />@Localizer["You know"]
-            </div>
-            <div class="square-block-title @SharedLocalizer["d-none"]">
-                @Localizer["You know"] <br />
-                <span class="green">
-                    @Localizer["Blockchain"]
-                </span>
-            </div>
-            <div class="square-block-subtitle">
-                @Localizer["Write smart contracts in a language you already love"]
-            </div>
-        </div>
+        @{
+            ViewData["CS_customClasses"] = "blockchain";
+            ViewData["CS_title"] = @Localizer["Blockchain You know"].Value;
+            ViewData["CS_subtitle"] = @Localizer["Write smart contracts in a language you already love"].Value;
+        }
+        <partial name="../_Common/_CaptionSquare" view-data="ViewData" />
+
         <a class="btn-2 code-learn-more" href="/technology#smart-contracts">@Localizer["Learn More"]</a>
     </div>
 
@@ -229,6 +209,7 @@
 
     <div class="dual-tokens-row">
         <div class="col-left">
+
             <div class="square-block dual-tokens">
                 <div class="square-block-title">
                     <span class="green">@Localizer["Dual"]</span><br />
@@ -238,6 +219,8 @@
                     @Localizer["Neo has a unique dual token model that separates governance from utility."]
                 </div>
             </div>
+
+
         </div>
         <div class="col-right header-imgs">
             <div class="header-img-wrapper">

--- a/NeoWeb/Views/_Common/_CaptionSquare.cshtml
+++ b/NeoWeb/Views/_Common/_CaptionSquare.cshtml
@@ -4,11 +4,13 @@
 <div class="caption-square-container @ViewData["CS_customClasses"]">
     <div class="caption-square-inner-wrapper">
         <div class="title">@Html.Raw(ViewData["CS_title"])</div>
-        @if (@ViewData["SB_subtitle"] != null)
-        {
-            <div class="subtitle">
-                @Html.Raw(ViewData["CS_subtitle"])
-            </div>
+        @{
+            if (@ViewData["CS_subtitle"] != null)
+            {
+                <div class="subtitle">
+                    @Html.Raw(ViewData["CS_subtitle"])
+                </div>
+            }
         }
     </div>
 </div>

--- a/NeoWeb/Views/_Common/_CaptionSquare.cshtml
+++ b/NeoWeb/Views/_Common/_CaptionSquare.cshtml
@@ -1,0 +1,14 @@
+@using Microsoft.AspNetCore.Mvc.Localization
+@inject IHtmlLocalizer<SharedResource> SharedLocalizer
+
+<div class="caption-square-container @ViewData["CS_customClasses"]">
+    <div class="caption-square-inner-wrapper">
+        <div class="title">@Html.Raw(ViewData["CS_title"])</div>
+        @if (@ViewData["SB_subtitle"] != null)
+        {
+            <div class="subtitle">
+                @Html.Raw(ViewData["CS_subtitle"])
+            </div>
+        }
+    </div>
+</div>

--- a/NeoWeb/wwwroot/css/_caption-square.less
+++ b/NeoWeb/wwwroot/css/_caption-square.less
@@ -9,7 +9,6 @@
   padding: 12px;
   text-align: left;
 
-
   @media (min-width: 768px) {
     border-width: 3px;
     width: 230px;
@@ -18,11 +17,17 @@
   }
 
   @media (min-width: 1024px) {
-
+    border-width: 4px;
+    width: 330px;
+    height: 220px;
+    padding: 24px;
   }
 
   @media (min-width: 1440px) {
-
+    border-width: 6px;
+    width: 460px;
+    height: 300px;
+    padding: 32px;
   }
 
   .caption-square-inner-wrapper {
@@ -42,13 +47,13 @@
       }
 
       @media (min-width: 1024px) {
-        font-size: @font-size-41px;
+        font-size: @font-size-36px;
         line-height: 1.1;
         margin-bottom: 0.625rem;
       }
 
       @media (min-width: 1440px) {
-        font-size: @font-size-58px;
+        font-size: @font-size-50px;
         margin-bottom: 1.125rem;
       }
 
@@ -69,6 +74,14 @@
         font-size: @font-size-20px;
         line-height: 1.2;
       }
+
+      @media (min-width: 1024px) {
+        font-size: @font-size-18px;
+      }
+
+      @media (min-width: 1440px) {
+        font-size: @font-size-24px;
+      }
     }
   }
 }
@@ -76,6 +89,31 @@
 // Customizations
 
 .caption-square-container {
+  &.building-blocks {
+    @media (min-width: 1024px) {
+      height: 300px;
+    }
+
+    @media (min-width: 1440px) {
+      height: 420px;
+    }
+
+    .title {
+      @media (min-width: 1024px) {
+        font-size: @font-size-41px;
+      }
+
+      @media (min-width: 1440px) {
+        font-size: @font-size-58px;
+      }
+    }
+  }
+
+  &.blockchain {
+  }
+
+  &.dual-tokens {
+  }
 
   &.governance {
     @media (min-width: 768px) {
@@ -90,8 +128,14 @@
       @media (min-width: 768px) {
         font-size: @font-size-26px;
       }
+
+      @media (min-width: 1024px) {
+        font-size: @font-size-36px;
+      }
+
+      @media (min-width: 1440px) {
+        font-size: @font-size-48px;
+      }
     }
   }
-
-
 }

--- a/NeoWeb/wwwroot/css/_caption-square.less
+++ b/NeoWeb/wwwroot/css/_caption-square.less
@@ -1,0 +1,56 @@
+@import "./basic.less";
+
+.caption-square-container {
+  padding: 3.125rem 2.25rem 3.125rem 0.5rem;
+  // border: 6px solid @green;
+  border: 6px solid orange;
+  box-sizing: border-box;
+
+  .caption-square-inner-wrapper {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: flex-end;
+    text-align: right;
+
+    .title {
+      .work-sans-bold;
+      .uppercase;
+      font-size: @font-size-38px;
+      line-height: 1;
+      margin-bottom: 0.75rem;
+
+      @media (min-width: 768px) {
+        font-size: @font-size-30px;
+      }
+
+      @media (min-width: 1024px) {
+        font-size: @font-size-41px;
+        line-height: 1.1;
+        margin-bottom: 0.625rem;
+      }
+
+      @media (min-width: 1440px) {
+        font-size: @font-size-58px;
+        margin-bottom: 1.125rem;
+      }
+
+      em {
+        font-style: normal;
+        color: @green;
+      }
+    }
+
+    .subtitle {
+      .nunito-sans-bold;
+      .dark-blue;
+      font-size: @font-size-25px;
+      line-height: 1.23;
+
+      @media (min-width: 768px) {
+        font-size: @font-size-20px;
+        line-height: 1.2;
+      }
+    }
+  }
+}

--- a/NeoWeb/wwwroot/css/_caption-square.less
+++ b/NeoWeb/wwwroot/css/_caption-square.less
@@ -1,24 +1,41 @@
 @import "./basic.less";
 
 .caption-square-container {
-  padding: 3.125rem 2.25rem 3.125rem 0.5rem;
-  // border: 6px solid @green;
-  border: 6px solid orange;
+  border: 6px solid @green;
+  background-color: white;
   box-sizing: border-box;
+  width: 312px;
+  height: 312px;
+  padding: 12px;
+  text-align: left;
+
+
+  @media (min-width: 768px) {
+    border-width: 3px;
+    width: 230px;
+    height: 230px;
+    text-align: right;
+  }
+
+  @media (min-width: 1024px) {
+
+  }
+
+  @media (min-width: 1440px) {
+
+  }
 
   .caption-square-inner-wrapper {
+    height: 100%;
     display: flex;
     flex-direction: column;
     justify-content: center;
-    align-items: flex-end;
-    text-align: right;
 
     .title {
       .work-sans-bold;
       .uppercase;
       font-size: @font-size-38px;
       line-height: 1;
-      margin-bottom: 0.75rem;
 
       @media (min-width: 768px) {
         font-size: @font-size-30px;
@@ -46,6 +63,7 @@
       .dark-blue;
       font-size: @font-size-25px;
       line-height: 1.23;
+      padding-top: 18px;
 
       @media (min-width: 768px) {
         font-size: @font-size-20px;
@@ -53,4 +71,27 @@
       }
     }
   }
+}
+
+// Customizations
+
+.caption-square-container {
+
+  &.governance {
+    @media (min-width: 768px) {
+      text-align: left;
+    }
+  }
+
+  &.contributors {
+    .title {
+      font-size: @font-size-33px;
+
+      @media (min-width: 768px) {
+        font-size: @font-size-26px;
+      }
+    }
+  }
+
+
 }

--- a/NeoWeb/wwwroot/css/basic.less
+++ b/NeoWeb/wwwroot/css/basic.less
@@ -43,6 +43,7 @@
 @font-size-42px: 2.625rem;
 @font-size-43px: 2.688rem;
 @font-size-44px: 2.75rem;
+@font-size-48px: 3rem;
 @font-size-50px: 3.125rem;
 @font-size-57px: 3.563rem;
 @font-size-58px: 3.625rem;

--- a/NeoWeb/wwwroot/css/home.less
+++ b/NeoWeb/wwwroot/css/home.less
@@ -126,219 +126,6 @@ html body {
     border-radius: 50%;
 }
 
-.square-block {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: flex-end;
-    text-align: right;
-    padding: 3.125rem 2.25rem 3.125rem 0.5rem;
-    border: 6px solid @green;
-
-    .square-block-title {
-        .work-sans-bold;
-        .uppercase;
-        font-size: @font-size-38px;
-        line-height: 1;
-        margin-bottom: 0.75rem;
-
-        @media (min-width: 768px) {
-            font-size: @font-size-30px;
-        }
-
-        @media (min-width: 1024px) {
-            font-size: @font-size-41px;
-            line-height: 1.1;
-            margin-bottom: 0.625rem;
-        }
-
-        @media (min-width: 1440px) {
-            font-size: @font-size-58px;
-            margin-bottom: 1.125rem;
-        }
-    }
-
-    .square-block-subtitle {
-        .nunito-sans-bold;
-        .dark-blue;
-        font-size: @font-size-25px;
-        line-height: 1.23;
-
-        @media (min-width: 768px) {
-            font-size: @font-size-20px;
-            line-height: 1.2;
-        }
-    }
-
-    &.building-blocks {
-        height: 26.25rem;
-        width: 28.75rem;
-
-        &.zh {
-            .square-block-title {
-                display: flex;
-                flex-direction: column;
-                justify-content: center;
-                align-items: flex-end;
-                font-size: 3.75rem;
-                line-height: 1.4;
-                margin-bottom: 0;
-            }
-        }
-    }
-
-    &.blockchain {
-        align-self: flex-end;
-        width: 29.375rem;
-        height: 18.25rem;
-    }
-
-    &.dual-tokens {
-        margin-top: 1.75rem;
-        padding-right: 2.375rem;
-        padding-left: 4.5rem;
-        width: 26.25rem;
-        height: 19.875rem;
-    }
-
-    &.governance {
-        align-items: flex-start;
-        text-align: left;
-        padding-left: 2.25rem;
-        padding-right: 0.5rem;
-        width: 30rem;
-        height: 17.375rem;
-    }
-
-    &.contributors {
-        padding-left: 0.5rem;
-        padding-right: 1.5rem;
-        width: 30.125rem;
-        height: 18rem;
-
-        .square-block-title {
-            font-size: 3.125rem;
-            line-height: 1;
-        }
-    }
-
-    @media only screen and (max-width: 1200px) {
-        padding: 1.5rem 0.5rem 1rem 0.5rem;
-        border: 3px solid @green;
-
-        &.building-blocks {
-            width: 14.375rem;
-            height: 13.125rem;
-
-            &.zh {
-                .square-block-title {
-                    display: flex;
-                    flex-direction: column;
-                    justify-content: center;
-                    align-items: flex-end;
-                    font-size: 2.75rem;
-                    line-height: 1.2;
-                    margin-bottom: 0;
-                }
-            }
-        }
-
-        &.blockchain {
-            margin-right: 12px;
-            align-self: flex-end;
-            align-items: flex-start;
-            padding-left: 0.75rem;
-            padding-right: 0.1rem;
-            text-align: left;
-            width: 14.375rem;
-            height: 13.125rem;
-        }
-
-        &.dual-tokens {
-            margin-top: 1.25rem;
-            padding-right: 0.5rem;
-            padding-left: 0.5rem;
-            width: 14.375rem;
-            height: 13.125rem;
-        }
-
-        &.governance {
-            align-items: flex-start;
-            text-align: left;
-            padding-left: 0.625rem;
-            padding-right: 0.1rem;
-            width: 14.375rem;
-            height: 11.875rem;
-        }
-
-        &.contributors {
-            padding-left: 0.625rem;
-            padding-right: 0.5rem;
-            width: 14.375rem;
-            height: 11.875rem;
-
-            .square-block-title {
-                font-size: 1.625rem;
-            }
-        }
-    }
-
-    @media only screen and (max-width: 767.98px) {
-        align-self: center;
-        align-items: flex-start;
-        text-align: left;
-        border: 5px solid @green;
-        width: 16.5rem;
-        height: 18.125rem;
-
-        &.building-blocks {
-            padding: 1.875rem 0.5rem 1.25rem 0.875rem;
-            width: 18.125rem;
-            height: 16.5rem;
-
-            &.zh {
-                .square-block-title {
-                    align-items: flex-start;
-                    font-size: 3.25rem;
-                    line-height: 1.1;
-                    margin-bottom: 0;
-                }
-            }
-        }
-
-        &.blockchain {
-            align-self: center;
-            padding: 1.875rem 0.5rem 1.25rem 0.875rem;
-            width: 18.125rem;
-            height: 16.5rem;
-        }
-
-        &.dual-tokens {
-            padding: 1.875rem 0.5rem 1.25rem 0.875rem;
-            width: 18.125rem;
-            height: 16.875rem;
-        }
-
-        &.governance {
-            padding: 1.875rem 0.5rem 1.25rem 0.5rem;
-            width: 18.125rem;
-            height: 16.75rem;
-        }
-
-        &.contributors {
-            padding: 1.875rem 0.3rem 1.25rem 0.5rem;
-            width: 18.125rem;
-            height: 16.75rem;
-
-            .square-block-title {
-                font-size: 2rem;
-                line-height: 0.94;
-            }
-        }
-    }
-}
-
-
 // Landing
 .landing-row {
     display: flex;
@@ -981,6 +768,14 @@ html body {
     }
 }
 
+.blockchain-caption-square-row {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    padding: 0 12px;
+}
+
 .code-square-body {
     margin-top: 1.125rem;
     .nunito-sans-bold;
@@ -1001,7 +796,7 @@ html body {
     z-index: 1;
 
     @media only screen and (max-width: 1200px) {
-        margin-right: 12px;
+        // margin-right: 12px;
     }
 
     @media only screen and (max-width: 767.98px) {

--- a/NeoWeb/wwwroot/css/home.less
+++ b/NeoWeb/wwwroot/css/home.less
@@ -1,5 +1,8 @@
 @import "basic.less";
 
+// Resuable UI partials used in this page
+@import './_caption-square.less';
+
 @landing-height: 80vh;
 @content-wrapper-margin: 120px;
 


### PR DESCRIPTION
Implement "Caption Square" partial on the homepage to better fit the design (per Design Files v0.09).

![image](https://user-images.githubusercontent.com/146148/116670082-a8862a00-a9e2-11eb-8b32-c292b1860f6f.png)

* Consolidate all variants of `.square-block` HTML elements into single reusable UI component
* @chenzhitong I made changes to its i18n definitions in the resource file for better cross-language style support
  * So there is no longer required to declare HTML blocks twice: one for English, one for Chinese
* Although similar styles, this "Caption Square" is not the same reusable partial as the "Latest News" caption.