### PR TITLE
Style fix to prevent top navigation bar from blocking the view/ability to close code window in mobile viewport

### DIFF
--- a/NeoWeb/Views/Home/Index.cshtml
+++ b/NeoWeb/Views/Home/Index.cshtml
@@ -596,11 +596,13 @@
 
         $(".language-icon").on("click", function () {
             $(".language-icon.selected").removeClass("selected")
-            $(this).addClass("selected")
+            const $el = $(this)
+            $el.addClass("selected")
 
-            const lang = $(this).data("lang")
+            const lang = $el.data("lang")
             $(".code-window").addClass("d-none")
             $("#code-" + lang).removeClass("d-none")
+            $('html').attr('data-code-window-open', lang)
         })
 
         $("#calculator-slider").on("input", function (e) {
@@ -685,6 +687,7 @@
         $(".close-icon").on("click", function () {
             $(".language-icon.selected").removeClass("selected");
             $(".code-window").addClass("d-none")
+            $('html').removeAttr('data-code-window-open')
         })
 
         const initialRun = resizeHandler.bind(this)

--- a/NeoWeb/wwwroot/css/site.less
+++ b/NeoWeb/wwwroot/css/site.less
@@ -335,6 +335,12 @@ table, .table {
         transition: transform 0.3s ease-in-out;
     }
 }
+// Prevent display of navbar in small viewport when code window is opened
+html[data-code-window-open] .navbar {
+    @media only screen and (max-width: 767.98px) {
+        display: none;
+    }
+}
 
 //面包屑导航条
 .bread-crumb {


### PR DESCRIPTION
Implement simple fix to prevent the "close" button from been blocked thus unable to move out from the code window on a mobile.

![image](https://user-images.githubusercontent.com/146148/117738280-031f5180-b23f-11eb-9243-109c9f97838b.png)

Solution methodology:

* Attach `data-code-window-open="<LANG>"` attribute to HTML when a example language is selected
* Use CSS to hard block mobile navigation bar from showing when `data-code-window-open` exists

![image](https://user-images.githubusercontent.com/146148/117738459-66a97f00-b23f-11eb-96bb-cf52229d6b73.png)
